### PR TITLE
Add additional copy and formatting options

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,10 +143,13 @@ fn config_path() -> PathBuf {
         .join("settings.json")
 }
 
-fn collect_urls(logs: &[arcdpslog::Log]) -> String {
+fn collect_urls(logs: &[arcdpslog::Log], only_success: bool) -> String {
     let mut urls = vec![];
     for l in logs {
         if let Step::Done(ref dpsreport) = l.dpsreport {
+            if only_success && !dpsreport.encounter.success {
+                continue
+            }
             urls.push(dpsreport.permalink.as_str());
         }
     }
@@ -408,7 +411,13 @@ fn render_fn(ui: &Ui) {
                     }
                 });
                 if ui.button(e("Copy dps.report urls")) {
-                    let urls = collect_urls(&logs);
+                    let urls = collect_urls(&logs, false);
+                    if !urls.is_empty() {
+                        ui.set_clipboard_text(urls);
+                    }
+                }
+                if ui.button(e("Copy dps.report urls (success)")) {
+                    let urls = collect_urls(&logs, true);
                     if !urls.is_empty() {
                         ui.set_clipboard_text(urls);
                     }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -242,6 +242,17 @@ pub fn render(ui: &Ui) {
         ui.input_text(e("dps.report copy format"), copyformat)
             .read_only(!EDIT_COPYFORMAT.get())
             .build();
+        ui.help_marker(|| {
+            ui.tooltip(|| {
+                ui.text(
+                    "You can configure the format that your dps.report url strings are copied as using the following parameters:",
+                );
+                ui.text("@1 - dps.report url");
+                ui.text("@2 - boss name and CM status");
+                ui.text("@3 - boss id");
+                ui.text("@4 - encounter success/fail");
+            })
+        });
     });
     ui.same_line();
     if ui.button(if !EDIT_COPYFORMAT.get() {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -31,6 +31,8 @@ pub struct Settings {
     pub dpsreport_copyformat: String,
     #[serde(default)]
     pub show_window: bool,
+    #[serde(default)]
+    pub copy_success: bool,
     #[serde(default = "default_true")]
     pub enable_dpsreport: bool,
     #[serde(default = "default_true")]
@@ -48,6 +50,7 @@ impl Settings {
             dpsreport_token: String::new(),
             dpsreport_copyformat: String::new(),
             show_window: true,
+            copy_success: false,
             enable_dpsreport: true,
             enable_wingman: true,
             filter_wingman: Vec::new(),
@@ -81,6 +84,10 @@ impl Settings {
 
     pub fn show_window(&self) -> bool {
         self.show_window
+    }
+    
+    pub fn copy_success(&self) -> bool {
+        self.copy_success
     }
 
     pub fn enable_dpsreport(&self) -> bool {


### PR DESCRIPTION
This PR adds the following features:
- Toggle option to copy only dps.report urls for all logs or only successful logs
- Option to copy dps.report urls using provided formatting string (similar to arcdps damage title bar formatting)
 
![image](https://github.com/user-attachments/assets/d56dcaa8-3f2b-4b16-9ca7-b98f86e7cf24)
![image](https://github.com/user-attachments/assets/85989c90-2249-4b34-86c0-4504cf848c0b)

