### PR TITLE
Raise nexus events on log detection and upload completion

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -1,10 +1,55 @@
+use std::ffi::CString;
+
 use anyhow::Result;
+use nexus::event::Event;
 use revtc::evtc::Encounter;
 
 use crate::dpsreport::DpsReportResponse;
 
 pub const RED: [f32; 4] = [1.0, 0.0, 0.0, 1.0];
 pub const GREEN: [f32; 4] = [0.0, 1.0, 0.0, 1.0];
+
+// Events for other addons to subscribe to
+pub const EV_LOG_DETECTED: Event<LogDetectedEvent> =
+    unsafe { Event::new("EV_ARCDPS_LOG_UPLOADER_LOG_DETECTED") };
+pub const EV_LOG_PARSED: Event<LogParsedEvent> =
+    unsafe { Event::new("EV_ARCDPS_LOG_UPLOADER_LOG_PARSED") };
+pub const EV_DPSREPORT: Event<DpsReportEvent> =
+    unsafe { Event::new("EV_ARCDPS_LOG_UPLOADER_DPSREPORT") };
+pub const EV_WINGMAN: Event<WingmanEvent> =
+    unsafe { Event::new("EV_ARCDPS_LOG_UPLOADER_WINGMAN") };
+
+#[repr(C)]
+pub struct LogDetectedEvent {
+    pub file_path: *const std::ffi::c_char,
+}
+
+#[repr(C)]
+pub struct LogParsedEvent {
+    pub file_path: *const std::ffi::c_char,
+    pub boss_id: u16,
+    pub player_count: u32,
+}
+
+#[repr(C)]
+pub struct DpsReportEvent {
+    pub file_path: *const std::ffi::c_char,
+    pub permalink: *const std::ffi::c_char,
+    pub boss_id: i64,
+    pub success: bool,
+}
+
+#[repr(C)]
+pub struct WingmanEvent {
+    pub file_path: *const std::ffi::c_char,
+    pub boss_id: u16,
+    pub accepted: bool,
+}
+
+// helper to get a CString from a PathBuf, lossy
+pub fn path_to_cstring(path: &std::path::Path) -> CString {
+    CString::new(path.to_string_lossy().as_bytes()).unwrap_or_default()
+}
 
 #[derive(Debug)]
 pub struct WorkerMessage {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -270,6 +270,10 @@ fn get_new_logs(logs: &mut Vec<arcdpslog::Log>) {
     while let Ok(iter) = file_rx.next_log() {
         for l in iter {
             log::info!("New log found: {}", l.display());
+            let cpath = common::path_to_cstring(&l);
+            EV_LOG_DETECTED.raise(&LogDetectedEvent {
+                file_path: cpath.as_ptr(),
+            });
             logs.push(arcdpslog::Log::new(l));
         }
     }
@@ -279,6 +283,14 @@ fn update_logs(logs: &mut [arcdpslog::Log]) {
     while let Some(WorkerMessage { index, payload }) = STATE.try_next_producer() {
         match payload {
             WorkerType::Evtc(evtc) => {
+                if let Ok(ref enc) = evtc {
+                    let cpath = common::path_to_cstring(&logs[index].location);
+                    EV_LOG_PARSED.raise(&LogParsedEvent {
+                        file_path: cpath.as_ptr(),
+                        boss_id: enc.header.boss_id,
+                        player_count: enc.agents.len() as u32,
+                    });
+                }
                 logs[index].evtc = Step::from_value(evtc);
             }
             WorkerType::DpsReport(r) => match r {
@@ -293,6 +305,15 @@ fn update_logs(logs: &mut [arcdpslog::Log]) {
                             log::error!("Failed to store settings: {e}");
                         });
                     };
+                    let cpath = common::path_to_cstring(&logs[index].location);
+                    let cpermalink =
+                        std::ffi::CString::new(r.permalink.as_str()).unwrap_or_default();
+                    EV_DPSREPORT.raise(&DpsReportEvent {
+                        file_path: cpath.as_ptr(),
+                        permalink: cpermalink.as_ptr(),
+                        boss_id: r.encounter.boss_id,
+                        success: r.encounter.success,
+                    });
                     logs[index].dpsreport = Step::from_value(Ok(r));
                 }
                 Ok(Err(e)) => {
@@ -303,6 +324,18 @@ fn update_logs(logs: &mut [arcdpslog::Log]) {
                 }
             },
             WorkerType::Wingman(r) => {
+                if let Ok(accepted) = &r {
+                    let cpath = common::path_to_cstring(&logs[index].location);
+                    let boss_id = match &logs[index].evtc {
+                        Step::Done(enc) => enc.header.boss_id,
+                        _ => 0,
+                    };
+                    EV_WINGMAN.raise(&WingmanEvent {
+                        file_path: cpath.as_ptr(),
+                        boss_id,
+                        accepted: *accepted,
+                    });
+                }
                 logs[index].wingman = Step::from_value(r);
             }
         }


### PR DESCRIPTION
Allows other addons to correlate in-game events with arcdps logs by subscribing to Nexus events raised at each stage of the pipeline:

- EV_ARCDPS_LOG_UPLOADER_LOG_DETECTED (file_path)
- EV_ARCDPS_LOG_UPLOADER_LOG_PARSED (file_path, boss_id, player_count)
- EV_ARCDPS_LOG_UPLOADER_DPSREPORT (file_path, permalink, boss_id, success)
- EV_ARCDPS_LOG_UPLOADER_WINGMAN (file_path, boss_id, accepted)

I tested that it builds and each of the events are being fired.